### PR TITLE
B 08623 add story narrative backend md

### DIFF
--- a/app/controllers/stories.controller.js
+++ b/app/controllers/stories.controller.js
@@ -2,17 +2,50 @@ const { where } = require("sequelize");
 const db = require("../models");
 const Story = db.story;
 const Op = db.Sequelize.Op;
-const { startCohereChat } = require('../services/cohere-client-service');
+const { startCohereChat, extendStory } = require('../services/cohere-client-service');
 
+/**
+ * Create new story
+ * @param {*} req 
+ * @param {*} res 
+ */
 exports.create = async (req, res) => {
+  const userId = req.params.userId;
+  const storyParams = req.body.storyParams;
+
   try {
-    const userId = req.params.userId;
-    const storyParams = req.body.storyParams;
-
     // Call the LLM service to generate the story text
-    const storyText = await startCohereChat(storyParams);
+    const preamble = 'You are a writer of children\'s stories';
+    let parametersText = '';
 
-    //TODO - save storyText to dB here before sending in the response.
+    let chatInputMessage = 'Please write me a 5 paragraph childrens bedtime story. ';
+
+    if (storyParams.length !== 0) {
+      storyParams.forEach(parameter => {
+        parametersText += `${parameter.key}: ${parameter.value}, `;
+      });
+    }
+
+    if (parametersText !== '') {
+      chatInputMessage += ` Please use the following parameters to help build the content of the story. ${parametersText}`;
+    }
+
+    chatInputMessage += ` End the story extension in a way that leaves the plot open for continuation. 
+    Do not say explicitaly that there will be another chapter, but rather build the plot in a 
+    way that allows space for more story to be generated. Do not use phrases like "The End...for now." OR "To be continued..."`;
+
+    const storyText = await startCohereChat(preamble, chatInputMessage);
+
+    const story = {
+      userId: userId,
+      story: storyText,
+      parentId: null,
+      createdAt: new Date(),
+      updatedAt: null,
+    };
+
+    await Story.create(story);
+
     try {
       res.send(storyText);
     } catch (error) {
@@ -23,9 +56,74 @@ exports.create = async (req, res) => {
     }
 
   } catch (error) {
-    console.error(`When creating story for user ${userId} with params ${storyParams} encountered error ${error}`);
+    console.error(`Creating story for user ${userId} with params ${storyParams} encountered error ${error}`);
     res.status(500).send({
       message: "An error occurred while creating the story.",
+    });
+  }
+};
+
+/**
+ * Create additional story record from existing story context.
+ * @param {*} req 
+ * @param {*} res 
+ */
+exports.extend = async (req, res) => {
+  const storyId = parseInt(req.params.storyId);
+  const storyParams = req.body.storyParams;
+
+  try {
+
+    const parentStory = await Story.findByPk(storyId);
+
+    const userId = parentStory.userId;
+    const storyContext = parentStory.story;
+
+    // Call the LLM service to generate the story text
+    const preamble = 'You are a writer of children\'s stories, who wants to extend an already written story with an engaging new entry.';
+    let parametersText = '';
+    let chatInputMessage = `Please generate a 5 paragraph extension of the following childrens bedtime story. 
+    Please maintain plot continuity from provided story, even if there are new parameters that will be added with the extension 
+    to the story. Here is the existing story: ${storyContext}`;
+
+    if (storyParams.length !== 0) {
+      storyParams.forEach(parameter => {
+        parametersText += `${parameter.key}: ${parameter.value}, `;
+      });
+    }
+
+    if (parametersText !== '') {
+      chatInputMessage += `Now, please also use the following parameters to help build the content of the story extension. ${parametersText}`;
+    }
+
+    chatInputMessage += ` End the story extension in a way that leaves the plot open for continuation. 
+    Do not say explicitaly that there will be another chapter, but rather build the plot in a 
+    way that allows space for more story to be generated. Do not use phrases like "The End...for now." OR "To be continued..."`;
+
+    const storyText = await startCohereChat(preamble, chatInputMessage);
+
+    const story = {
+      userId: userId,
+      story: storyText,
+      parentId: parentStory.storyId,
+      createdAt: new Date(),
+      updatedAt: null,
+    };
+
+    await Story.create(story);
+
+    try {
+      res.send(storyText);
+    } catch (error) {
+      console.error(`Response with story for user ${userId} with params ${storyParams} encountered error ${error}`);
+      res.status(500).send({
+        message: "An error occurred while returning the extended story.",
+      });
+    }
+  } catch (error) {
+    console.error(`Extending story for user ${userId} with params ${storyParams} encountered error ${error}`);
+    res.status(500).send({
+      message: "An error occurred while extending the story.",
     });
   }
 };
@@ -34,15 +132,15 @@ exports.create = async (req, res) => {
 exports.findAll = (req, res) => {
   const storyId = req.query.storyId;
   var condition = storyId
-  ? {
+    ? {
       id: {
-          [Op.like]: `%${storyId}%`,
+        [Op.like]: `%${storyId}%`,
       },
-  }
-  : null;
+    }
+    : null;
 
-  Story.findAll({where: condition, order: [["name", "ASC"]]})
-  .then((data) => {
+  Story.findAll({ where: condition, order: [["name", "ASC"]] })
+    .then((data) => {
       res.send(data);
     })
     .catch((err) => {

--- a/app/models/stories.model.js
+++ b/app/models/stories.model.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, Sequelize) => {
         storyId: {
             type: Sequelize.INTEGER,
             primaryKey: true,
-            autoIncrement: false,
+            autoIncrement: true,
         },
         userId: {
             type: Sequelize.INTEGER,

--- a/app/routes/stories.routes.js
+++ b/app/routes/stories.routes.js
@@ -1,11 +1,13 @@
   module.exports = (app) => {
-    const Story = require("../controllers/story.controller.js");
+    const Story = require("../controllers/stories.controller.js");
     const { authenticateRoute } = require("../authentication/authentication");
     var router = require("express").Router();
   
     // Create a new Story
     router.post("/stories/:userId", Story.create);
 
+    router.post("/stories/extend/:storyId", Story.extend);
+  
     app.use("/storiesapi", router);
   };
   

--- a/app/services/cohere-client-service.js
+++ b/app/services/cohere-client-service.js
@@ -5,28 +5,15 @@ const cohere = new CohereClient({
 });
 
 /**
+ * 
  * Invokes Cohere API to generate story text.
- * 
- * @param {*} parameters - an iterable (list) of objects with a 
- * key and value * field in the, these "parameters" are passed to the Cohere API prompt
- * 
- * @returns New story as a string .
+ * @param {*} preamble - The prepatory statement for the LLM to generate text
+ * @param {*} chatInputMessage - The generated text that is to be sent to the LLM as a request or input.
+ * @returns New story as a string
  */
-async function startCohereChat(parameters) {
-    const preamble = 'You are a writer of children\'s stories';
+async function startCohereChat(preamble, chatInputMessage) {
+
     let responseTexts = '';
-    let parametersText = '';
-    let chatInputMessage = 'Can you please write me a 5 paragraph childrens bedtime story?';
-
-    if(parameters.length !== 0){
-       parameters.forEach(parameter => {
-            parametersText += `${parameter.key}: ${parameter.value}, `;
-       }); 
-    }
-
-    if(parametersText !== ''){
-        chatInputMessage += ` Please use the following parameters to help build the content of the story. ${parametersText}`;
-    }
 
     const chatStream = await cohere.chatStream({
         preamble: preamble,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,33 @@
         "supertest": "^6.3.3"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
+      "integrity": "sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
+      "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.6.tgz",
+      "integrity": "sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime-corejs3": {
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.2.tgz",
@@ -49,6 +76,19 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "node_modules/@babel/types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.6.tgz",
+      "integrity": "sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
@@ -276,22 +316,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@jest/core/node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/@babel/helper-validator-option": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
@@ -389,17 +413,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@jest/core/node_modules/@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jest/core/node_modules/@babel/plugin-syntax-async-generators": {
@@ -593,19 +606,6 @@
         "@babel/types": "^7.24.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -932,11 +932,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@jest/core/node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
     },
     "node_modules/@jest/core/node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2755,14 +2750,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
-    "node_modules/@jest/core/node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@jest/core/node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2922,11 +2909,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
-    "node_modules/@jest/types/node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
-    },
     "node_modules/@jest/types/node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
@@ -3007,6 +2989,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3015,10 +3014,41 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/validator": {
       "version": "13.11.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.10.tgz",
       "integrity": "sha512-e2PNXoXLr6Z+dbfx5zSh9TRlXJrELycxiaXznp4S5+D2M3b9bqJEitNHA5923jhnB2zzFiZHa2f0SI1HoIahpg=="
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -3450,6 +3480,19 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4279,22 +4322,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/jest-cli/node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/jest-cli/node_modules/@babel/helper-validator-option": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
@@ -4392,17 +4419,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/jest-cli/node_modules/@babel/plugin-syntax-async-generators": {
@@ -4596,19 +4612,6 @@
         "@babel/types": "^7.24.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4888,11 +4891,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/jest-cli/node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
     },
     "node_modules/jest-cli/node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -6554,14 +6552,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
-    "node_modules/jest-cli/node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/jest-cli/node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7482,6 +7472,14 @@
         "node": ">=6.4.0"
       }
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/toposort-class": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
@@ -7511,6 +7509,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/url-join": {
       "version": "4.0.1",


### PR DESCRIPTION
Completed extending parent story with new story entry. 

Technical notes:
This involved generally making the cohere client service generally "dumber" by pulling out the chat text details and placing them upstream in the controller. 

How it works:
This capability depends on an existing story id being provided as the "parent id" in the request. When the request is made, the parent story text is queried and used as an input to the new story extension process. This, in addition to additional new story parameters, will build a context on which the new story will be built, enabling the plot details of the first story to influence the events of the new story.

This capability can be invoked by calling {{baseUrl}}/storiesapi/stories/extend/:parentStoryId.
Just like the original story create endpoint, the body of the request can contain parameters for the story in an array of key/value pairs like:

```
{
    "storyParams": [
        {
            "key": "setting",
            "value": "The town of Derry"
        },
        {
            "key": "time of day",
            "value": "night"
        },
        {
            "key": "building condition",
            "value": "creaky floors"
        },
        {
            "key": "antagonist",
            "value": "Pennywise the clown"
        }
    ]
}
```